### PR TITLE
提供方法分离题目

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ Here are the fonts that this template will use, you can change the font by passi
 Refer to `main.typ` for a complete example.
 
 `main.typ` 提供了一个完整的示例。
+
+Refer to `main-modular.typ` & `problems/*.typ` for a complete example with separated problems.
+
+`main-modular.typ` & `problems/*.typ` 提供了一个将题目分离的完整的示例。

--- a/common.typ
+++ b/common.typ
@@ -1,0 +1,73 @@
+// Typst template for making NOI-like problems
+// Author: Wallbreaker5th
+// MIT-0 License
+
+#import "@preview/codelst:2.0.0": sourcecode
+
+#let 字号 = (
+  初号: 42pt,
+  小初: 36pt,
+  一号: 26pt,
+  小一: 24pt,
+  二号: 22pt,
+  小二: 18pt,
+  三号: 16pt,
+  小三: 15pt,
+  四号: 14pt,
+  中四: 13pt,
+  小四: 12pt,
+  五号: 10.5pt,
+  小五: 9pt,
+  六号: 7.5pt,
+  小六: 6.5pt,
+  七号: 5.5pt,
+  小七: 5pt,
+)
+
+#let default-fonts = (
+  mono: "Consolas",
+  serif: "New Computer Modern",
+  cjk-serif: "FZShuSong-Z01S",
+  cjk-sans: "FZHei-B01S",
+  cjk-mono: "FZFangSong-Z02S",
+  cjk-italic: "FZKai-Z03S",
+)
+
+
+#let empty-par = {
+  par()[
+    #v(0em, weak: true)
+    #h(0em)
+  ]
+}
+
+#let add-empty-par(it) = {
+  it
+  empty-par
+}
+
+
+#let default-problem-fullname(problem) = {
+  if (problem.at("name", default: none) != none) {
+    problem.name
+    if (problem.at("name-en", default: none) != none) {
+      "（" + problem.name-en + "）"
+    }
+  } else {
+    problem.at("name-en", default: "")
+  }
+}
+
+#let make-formula(s) = {
+  let numbers = s.matches(regex("[\d.]+"))
+  let last-end = 0
+  for n in numbers {
+    let start = n.start
+    let end = n.end
+    let number = n.text
+    s.slice(last-end, start)
+    math.equation(number)
+    last-end = end
+  }
+  s.slice(last-end, s.len())
+}

--- a/fuzzy-cnoi-statement-modular.typ
+++ b/fuzzy-cnoi-statement-modular.typ
@@ -1,0 +1,493 @@
+// Typst template for making NOI-like problems
+// Author: Wallbreaker5th
+// MIT-0 License
+
+#import "/common.typ": *
+
+#let cnoi-initialized-state = state("cnoi-initialized", false)
+#let contest-info-state = state("contest-info", ())
+#let contest-fonts-state = state("fonts", default-fonts)
+#let contest-header-state = state("header", [])
+#let contest-footer-state = state("footer", [])
+#let statement-page-begin-state = state("statement-page-begin", false)
+
+#let new-problem(meta) = {
+  [#metadata(meta)<cnoi-problem>]
+
+  context if contest-info-state.get() == () {
+    v(0pt)
+  } else {
+    pagebreak(weak: true)
+  }
+
+  statement-page-begin-state.update(true)
+  heading(level: 1, default-problem-fullname(meta))
+}
+
+#let get-current-problem(here) = {
+  let before-problem-metadata = query(selector(<cnoi-problem>).before(here))
+
+  let idx = before-problem-metadata.len() - 1
+
+  if (idx >= 0) { before-problem-metadata.last().value }
+}
+
+#let current-header = context {
+  let current-problem = get-current-problem(here())
+  let contest-info = contest-info-state.get()
+
+  set par(first-line-indent: 0em)
+  if (current-problem == none) {
+    return
+  }
+  set text(size: 字号.五号)
+  contest-info.name
+  h(1fr)
+  let round = contest-info.at("round", default: none)
+  if (round != none) {
+    round + " "
+  }
+  default-problem-fullname(current-problem)
+  v(-2pt)
+  line(length: 100%, stroke: 0.3pt)
+}
+
+#let current-footer = context {
+  let current-problem = get-current-problem(here())
+  let contest-info = contest-info-state.get()
+
+  if (current-problem == none) {
+    return
+  }
+  set text(size: 字号.五号)
+  align(center, {
+    [第]
+    counter(page).display()
+    [页]
+    h(2em)
+    [共]
+    context {
+      let cnt = counter(page).final().at(0)
+      link((page: cnt, x: 0pt, y: 0pt), text(fill: rgb("#00f"), [#cnt]))
+    }
+    [页]
+  })
+}
+
+
+#let contest-init(
+  contest-info,
+  custom-fonts: (:),
+  header: current-header,
+  footer: current-footer,
+  body,
+) = context {
+  contest-info-state.update(contest-info)
+  contest-fonts-state.update(default-fonts + custom-fonts)
+  contest-header-state.update(header)
+  contest-footer-state.update(footer)
+
+  body
+}
+
+
+
+#let init(it) = context {
+  if cnoi-initialized-state.get() == true {
+    return it
+  }
+
+  let fonts = contest-fonts-state.get()
+  let contest-info = contest-info-state.get()
+
+  set text(
+    font: (
+      (
+        name: fonts.serif,
+        covers: "latin-in-cjk",
+      ),
+      fonts.cjk-serif,
+    ),
+    size: 字号.小四,
+    lang: "zh",
+    region: "CN",
+  )
+  show emph: set text(font: (
+    (
+      name: fonts.serif,
+      covers: "latin-in-cjk",
+    ),
+    fonts.cjk-italic,
+  ))
+  show strong: st => {
+    // Dotted strong text
+    set text(font: (
+      (
+        name: fonts.serif,
+        covers: "latin-in-cjk",
+      ),
+      fonts.cjk-sans,
+    ))
+    show regex("\p{sc=Hani}+"): s => {
+      underline(s, offset: 3pt, stroke: (
+        cap: "round",
+        thickness: 0.1em,
+        dash: (array: (0em, 1em), phase: 0.5em),
+      ))
+    }
+    st
+  }
+  show raw: set text(
+    font: (
+      (
+        name: fonts.mono,
+        covers: "latin-in-cjk",
+      ),
+      fonts.cjk-mono,
+    ),
+    size: 字号.小四,
+  )
+
+  set list(indent: 1.75em, marker: ([•], [#h(-1em)•]))
+  set enum(
+    indent: 1.75em,
+    numbering: x => {
+      grid(
+        columns: (0em, auto),
+        align: bottom,
+        hide[悲], numbering("1.", x),
+      ) // As a workaround
+    },
+  )
+
+  show heading: set text(
+    font: (
+      (
+        name: fonts.serif,
+        covers: "latin-in-cjk",
+      ),
+      fonts.cjk-sans,
+    ),
+    weight: 500,
+  )
+  show heading.where(level: 1): it => {
+    set text(size: 字号.小二)
+    set heading(bookmarked: true)
+    pad(top: 8pt, align(center, it))
+  }
+  show heading.where(level: 2): it => {
+    set text(size: 字号.小四)
+    set heading(bookmarked: true)
+    pad(left: 1.5em, top: 1em, bottom: .5em, [【] + box(it.body) + [】])
+  }
+  show raw.where(block: true): it => {
+    show raw.line: it => {
+      if (it.text == "" and it.number == it.count) {
+        return
+      }
+      box(
+        grid(
+          columns: (0em, 1fr),
+          align: (right, left),
+          move(
+            text(str(it.number), fill: gray, size: 0.8em),
+            dx: -1em,
+            dy: 0.1em,
+          ),
+          it.body,
+        ),
+      )
+    }
+    pad(
+      rect(it, stroke: 0.5pt + rgb("#00f"), width: 100%, inset: (y: 0.7em)),
+      left: 0.5em,
+    )
+  }
+
+  let header = contest-header-state.get()
+  let footer = contest-footer-state.get()
+
+  // Page Layout
+  set page(
+    margin: 2.4cm,
+    header: header,
+    footer: context if (statement-page-begin-state.at(here())) {
+      footer
+    },
+  )
+
+  show table: pad.with(y: .5em)
+
+  set par(first-line-indent: (amount: 2em, all: true), leading: 0.7em)
+  // Looks right but I'm not sure about the exact value
+  set par(spacing: 0.6em)
+
+  cnoi-initialized-state.update(true)
+
+  it
+}
+
+#let title() = context {
+  let contest-info = contest-info-state.get()
+  let fonts = contest-fonts-state.get()
+
+  align(center, {
+    text(contest-info.name, size: 字号.二号, font: (
+      (
+        name: fonts.serif,
+        covers: "latin-in-cjk",
+      ),
+      fonts.cjk-sans,
+    ))
+
+    parbreak()
+    v(10pt)
+
+    let name-en = contest-info.at("name-en", default: none)
+    if (name-en != none) {
+      text(name-en, size: 字号.小一)
+      parbreak()
+      v(10pt)
+    }
+
+
+    let round = contest-info.at("round", default: none)
+    if (round != none) {
+      emph(text(round, size: 字号.二号))
+      parbreak()
+    }
+
+    let author = contest-info.at("author", default: none)
+    if (author != none) {
+      text(author, size: 字号.小三, font: (
+        (
+          name: fonts.serif,
+          covers: "latin-in-cjk",
+        ),
+        fonts.cjk-sans,
+      ))
+      parbreak()
+      v(5pt)
+    }
+
+    let time = contest-info.at("time", default: none)
+    if (time != none) {
+      text(time, size: 字号.小三, font: (
+        (
+          name: fonts.serif,
+          covers: "latin-in-cjk",
+        ),
+        fonts.cjk-sans,
+      ))
+    }
+  })
+}
+
+#let generate-problem-list() = {
+  let problem_list = ()
+  let metadata_items = query(metadata)
+
+
+  for (i, metadata) in metadata_items.enumerate() {
+    problem_list.push(metadata.value)
+  }
+
+  problem_list
+}
+
+#let problem-table(
+  extra-rows: (:),
+  languages: (("C++", "cpp"),),
+  compile-options: (("C++", "-O2 -std=c++14 -static"),),
+) = context {
+  let problem-list = generate-problem-list()
+
+  let default-row = (
+    wrap: text,
+    always-display: false,
+    default: "无",
+  )
+  let rows = (
+    (
+      name: (
+        name: "题目名称",
+        always-display: true,
+      ),
+      type: (
+        name: "题目类型",
+        always-display: true,
+        default: "传统型",
+      ),
+      name-en: (
+        name: "目录",
+        wrap: raw,
+        always-display: true,
+      ),
+      executable: (
+        name: "可执行文件名",
+        wrap: raw,
+        always-display: true,
+        default: x => x.name-en,
+      ),
+      input: (
+        name: "输入文件名",
+        wrap: raw,
+        always-display: true,
+        default: x => x.name-en + ".in",
+      ),
+      output: (
+        name: "输出文件名",
+        wrap: raw,
+        always-display: true,
+        default: x => x.name-en + ".out",
+      ),
+      time-limit: (
+        name: "每个测试点时限",
+        wrap: make-formula,
+      ),
+      memory-limit: (
+        name: "内存限制",
+        wrap: make-formula,
+      ),
+      test-case-count: (
+        name: "测试点数目",
+        default: "10",
+        wrap: make-formula,
+      ),
+      subtask-count: (
+        name: "子任务数目",
+        default: "1",
+      ),
+      test-case-equal: (
+        name: "测试点是否等分",
+        default: "是",
+      ),
+    )
+      + extra-rows
+  )
+  rows = rows
+    .pairs()
+    .map(
+      row => (row.at(0), default-row + row.at(1)),
+    )
+  set table(align: bottom)
+  let first-column-width = if (problem-list.len() <= 3) { 22% } else { 1fr }
+  let columns = (first-column-width,) + (1fr,) * problem-list.len()
+  table(
+    columns: columns,
+    stroke: 0.4pt,
+    ..{
+      rows
+        .filter(row => {
+          let (field, r) = row
+          if (r.always-display) {
+            true
+          } else {
+            problem-list.any(p => p.at(field, default: none) != none)
+          }
+        })
+        .map(row => {
+          let (field, r) = row
+          (text(r.name),)
+          problem-list.map(p => {
+            let v = p.at(field, default: none)
+            let w = if (v == none) {
+              if (type(r.default) == str) {
+                (r.wrap)(r.default)
+              } else if (type(r.default) == function) {
+                (r.wrap)((r.default)(p))
+              } else if (type(r.default) == content) {
+                (r.wrap)(r.default)
+              }
+            } else {
+              v
+            }
+
+            if (type(w) == str) {
+              (r.wrap)(w)
+            } else {
+              w
+            }
+          })
+        })
+        .flatten()
+    }
+  )
+
+  [提交源程序文件名]
+  table(
+    columns: columns,
+    stroke: 0.4pt,
+    align: horizon,
+    ..{
+      languages
+        .map(l => {
+          if (l.len() == 2) {
+            l += (1em,)
+          }
+          (text(size: l.at(2))[对于 #l.at(0) #h(1fr) 语言],)
+          problem-list.map(p => {
+            let v = p.at("submit-file-name", default: p.name-en + "." + l.at(1))
+            if (type(v) == str) {
+              raw(v)
+            } else if (type(v) == function) {
+              v(l.at(1))
+            } else {
+              v
+            }
+          })
+        })
+        .flatten()
+    }
+  )
+
+  [编译选项]
+  table(
+    columns: columns,
+    align: (left + bottom, center + bottom),
+    stroke: 0.4pt,
+    ..{
+      compile-options
+        .map(l => {
+          if (l.len() == 2) {
+            l += (1em,)
+          }
+          (
+            text(size: l.at(2))[对于 #l.at(0) #h(1fr) 语言],
+            table.cell(
+              colspan: problem-list.len(),
+              raw(l.at(1)),
+            ),
+          )
+        })
+        .flatten()
+    }
+  )
+}
+
+
+#let filename(it) = {
+  set text(style: "italic", weight: "bold")
+  it
+}
+
+#let current-filename(ext) = context {
+  let problem = get-current-problem(here())
+  filename(problem.at("name-en") + "." + ext)
+}
+
+#let current-sample-filename(idx, ext) = context {
+  let problem = get-current-problem(here())
+  filename(problem.at("name-en") + "/" + problem.at("name-en") + str(idx) + "." + ext)
+}
+
+#let data-constraints-table-args = {
+  (
+    stroke: (x, y) => (
+      left: if (x > 0) { .4pt },
+      bottom: 2pt,
+      top: if (y == 0) { 2pt } else if (y == 1) { 1.2pt } else { .4pt },
+    ),
+    align: center + horizon,
+  )
+}

--- a/fuzzy-cnoi-statement-modular.typ
+++ b/fuzzy-cnoi-statement-modular.typ
@@ -455,7 +455,7 @@
           (
             text(size: l.at(2))[对于 #l.at(0) #h(1fr) 语言],
             table.cell(
-              colspan: problem-list.len(),
+              colspan: calc.max(problem-list.len(), 1),
               raw(l.at(1)),
             ),
           )

--- a/fuzzy-cnoi-statement-standard.typ
+++ b/fuzzy-cnoi-statement-standard.typ
@@ -2,60 +2,7 @@
 // Author: Wallbreaker5th
 // MIT-0 License
 
-#import "@preview/codelst:2.0.0": sourcecode
-
-#let 字号 = (
-  初号: 42pt,
-  小初: 36pt,
-  一号: 26pt,
-  小一: 24pt,
-  二号: 22pt,
-  小二: 18pt,
-  三号: 16pt,
-  小三: 15pt,
-  四号: 14pt,
-  中四: 13pt,
-  小四: 12pt,
-  五号: 10.5pt,
-  小五: 9pt,
-  六号: 7.5pt,
-  小六: 6.5pt,
-  七号: 5.5pt,
-  小七: 5pt,
-)
-
-#let default-fonts = (
-  mono: "Consolas",
-  serif: "New Computer Modern",
-  cjk-serif: "FZShuSong-Z01S",
-  cjk-sans: "FZHei-B01S",
-  cjk-mono: "FZFangSong-Z02S",
-  cjk-italic: "FZKai-Z03S",
-)
-
-
-#let empty-par = {
-  par()[
-    #v(0em, weak: true)
-    #h(0em)
-  ]
-}
-#let add-empty-par(it) = {
-  it
-  empty-par
-}
-
-
-#let default-problem-fullname(problem) = {
-  if (problem.at("name", default: none) != none) {
-    problem.name
-    if (problem.at("name-en", default: none) != none) {
-      "（" + problem.name-en + "）"
-    }
-  } else {
-    problem.at("name-en", default: "")
-  }
-}
+#import "/common.typ": *
 
 #let default-header(contest-info, current-problem) = {
   set par(first-line-indent: 0em)
@@ -92,21 +39,6 @@
     [页]
   })
 }
-
-#let make-formula(s) = {
-  let numbers = s.matches(regex("[\d.]+"))
-  let last-end = 0
-  for n in numbers {
-    let start = n.start
-    let end = n.end
-    let number = n.text
-    s.slice(last-end, start)
-    math.equation(number)
-    last-end = end
-  }
-  s.slice(last-end, s.len())
-}
-
 
 #let current-problem-idx = counter("current-problem-idx")
 #let statement-page-begin = state("statement-page-begin", false)

--- a/fuzzy-cnoi-statement-standard.typ
+++ b/fuzzy-cnoi-statement-standard.typ
@@ -347,7 +347,7 @@
           (
             text(size: l.at(2))[对于 #l.at(0) #h(1fr) 语言],
             table.cell(
-              colspan: problem-list.len(),
+              colspan: calc.max(problem-list.len(), 1),
               raw(l.at(1))
             )
           )

--- a/lib.typ
+++ b/lib.typ
@@ -1,0 +1,2 @@
+#import "/fuzzy-cnoi-statement-standard.typ": document-class
+#import "/fuzzy-cnoi-statement-modular.typ": init, title, problem-table, new-problem, filename, current-filename, current-sample-filename, data-constraints-table-args, contest-init

--- a/template/main-modular.typ
+++ b/template/main-modular.typ
@@ -1,0 +1,96 @@
+#import "@preview/fuzzy-cnoi-statement:0.2.0": *
+
+// 以下有大量 Fancy 的设置项。你可以根据需求，注释掉你不需要的内容，或者将你需要的内容取消注释。
+
+#let contest-info = (
+  name: "全国中老年信息学奥林匹克竞赛",
+  name-en: "FCC ION 3202",      // 似乎也可以当成副标题用
+  round: "第一试",
+  time: "时间：2023 年 7 月 24 日 08:00 ~ 13:00",
+  // author: "破壁人五号"
+)
+
+#show: contest-init.with(
+  contest-info,
+  // custom-fonts 参数可以更改字体，字典各项的键值为：mono、serif、cjk-serif、cjk-sans、cjk-mono、cjk-italic，值为字体名。你可以只传入部分项。默认分别为：
+  // - Consolas
+  // - New Computer Modern
+  // - 方正书宋（FZShuSong-Z01S）
+  // - 方正黑体（FZHei-B01S）
+  // - 方正仿宋（FZFangSong-Z02S）
+  // - 方正楷体（FZKai-Z03S）
+  // header 参数可以自定义页眉
+  // footer 参数可以自定义页脚
+)
+
+#show: init
+
+#title()
+
+#problem-table(
+  // 默认会显示以下行（括号内为默认值，打星号的在没有题目有这一项时不会显示）：
+  // - name 题目名称（无）
+  // - type 题目类型（传统型）
+  // - name-en 目录
+  // - executable 可执行文件名（默认为目录名）
+  // - input 输入文件名（默认为目录名 + ".in"）
+  // - output 输出文件名（默认为目录名 + ".out"）
+  // - * time-limit 每个测试点时限（无）
+  // - * memory-limit 内存限制（无）
+  // - * test-case-count 测试点数目（10）
+  // - * subtask-count 子任务数目（1）
+  // - * test-case-equal 测试点是否等分（是）
+  // 
+  // 一般来说，默认显示的行的设置是够用的。但如果你希望增加更多行，或者当你有太多题目需要展示，你可能需要 extra-rows 参数来添加新的行。
+  // extra-rows 也可以覆盖掉默认的行。其在题目过多、需要将特定行的字体变小时尤其有用。
+  extra-rows:(
+    year: (                   // 对应的 field 名
+      name: "年份",           // 显示的名字；可以用 content（调整字号等）
+      wrap: text,             // 显示的样式：若题目的这一项是 str，则显示为 wrap(str)，否则会直接显示这一项。默认为 text。
+      always-display: false,  // 是否总是显示：若为 false，则至少要有一个题目有这一项才会显示。默认为 false。
+      default: "2023"         // 默认值，默认为“无”。你也可以传入一个函数，其接受一个参数，为当前题目的信息，返回一个 str 或 content。
+    ),
+    contest: (
+      name: "赛事",
+      wrap: text.with(fill: blue), // 你也可以在这里设置更小的字体
+      always-display: true,
+      default: "NOI"
+    ),
+    setter: (
+      // name: text(size: 0.8em)[出题人], // 也许你需要更小的字号
+      name: "出题人",
+      always-display: true,
+      default: p => { p.name-en + "的出题人" }
+    ),
+    foo: (
+      name: "bar",
+      wrap: text,
+      default: "这一行不会显示"
+    )
+  ),
+  // 提交源程序文件名的列表，每一种语言为 (语言名, 文件后缀名) 的二元组，或 (语言名, 文件后缀名, 首列字体大小) 的三元组。若 problem 没有指明 submit-file-name，则用题目英文名与后缀名拼接。
+  languages:(
+    ("C++", "cpp"),
+    ("D++", "dpp"),
+    // ("D++", "dpp", 0.8em), // 更小的字号
+  ),
+  // 各个语言的编译选项，每一种语言为 (语言名, 编译选项) 的二元组，或 (语言名, 编译选项, 首列字体大小) 的三元组。
+  compile-options: (
+    ("C++", "-O2 -std=c++20 -DOFFLINE_JUDGE"),
+  )
+)
+
+*注意事项（请仔细阅读）*
++ 文件名（程序名和输入输出文件名）必须使用英文小写。
++ C++ 中函数 main() 的返回值类型必须是 int，程序正常结束时的返回值必须是 0。
++ 因违反以上两点而出现的错误或问题，申诉时一律不予受理。
++ 若无特殊说明，结果的比较方式为全文比较（过滤行末空格及文末回车）。
++ 选手提交的程序源文件必须不大于 100KB。
++ 程序可使用的栈空间内存限制与题目的内存限制一致。
++ 只提供 Linux 格式附加样例文件。
++ 禁止在源代码中改变编译器参数（如使用 \#pragma 命令），禁止使用系统结构相关指令（如内联汇编）和其他可能造成不公平的方法。
+
+
+#include "problems/problem-1.typ" 
+#include "problems/problem-2.typ" 
+#include "problems/problem-3.typ" 

--- a/template/main.typ
+++ b/template/main.typ
@@ -1,4 +1,4 @@
-#import "@preview/fuzzy-cnoi-statement:0.1.3": *;
+#import "@preview/fuzzy-cnoi-statement:0.2.0": document-class
 
 // 以下有大量 Fancy 的设置项。你可以根据需求，注释掉你不需要的内容，或者将你需要的内容取消注释。
 

--- a/template/problems/problem-1.typ
+++ b/template/problems/problem-1.typ
@@ -1,0 +1,95 @@
+#import "@preview/fuzzy-cnoi-statement:0.2.0": *
+
+#show: init
+
+#new-problem(
+    (
+    name: "圆格染色",            // 题目名
+    name-en: "color",           // 英文题目名，同时也是目录
+    time-limit: "1.0 秒",       // 每个测试点时限（会显示为 $1.0$ 秒）
+    memory-limit: "512 MiB",    // 内存限制（显示同上）
+    test-case-count: "10",      // 测试点数目（显示同上）
+    test-case-equal: "是",      // 测试点是否等分
+    year: "2023",               // 你可以添加自定义的属性
+  )
+)
+
+
+== 题目描述
+
+输入两个正整数 $a, b$，输出它们的和。
+
+你可以*强调一段带 $f+or+mu+l+a$ 的文本*。用 `#underline` 加 ``` `` ``` 来实现 #underline[`underlined raw text`]。
++ 第一点
++ 第二点
+
+- 第一点
+  - 列表可以嵌套
+  - 但目前，有序列表和无序列表的互相嵌套会有缩进上的问题。
+- 第二点
+  - 第二点的第一点
+  - 第二点的第二点
+
+
+== 输入格式
+
+从文件 #current-filename("in") 中读入数据。// 自动获取当前题目的输入文件名
+
+输入的第一行包含两个正整数 $a, b$，表示需要求和的两个数。
+
+== 输出格式
+
+输出到文件 #filename[color.out] 中。
+
+输出一行一个整数，表示 $a+b$。
+
+== 样例1输入
+// 从文件中读取样例
+#raw(read("../color1.in"), block: true)
+
+== 样例1输出
+// 或者直接写在文档中
+```text
+13
+```
+
+== 样例1解释
+
+#figure(caption: "凹包")[#image("../fig.png", width: 40%)]<aobao>
+
+如@aobao，这是一个凹包。
+
+#for (i,case) in range(2, 8).zip((
+  $1 tilde 5$,
+  $6 tilde 9$,
+  $10 tilde 13$,
+  $14 tilde 17$,
+  $18 tilde 19$,
+  $20$)){[
+== 样例#{i+2}
+见选手目录下的 #current-sample-filename(i, "in") 与 #current-sample-filename(i, "ans")。
+
+这个样例满足测试点 #case 的条件限制。
+]}
+
+== 数据范围
+
+对于所有测试数据保证：$1 <= a,b <= 10^9$。
+
+#figure(
+  table(
+    columns: 4,
+    ..data-constraints-table-args, // 默认的针对数据范围的三线表样式
+    table.header(
+    [测试点编号],   $n,m <=$,                      $q<=$,                          [特殊性质],
+    ),
+    $1 tilde 5$,   $300$,                         $300$,                          table.cell(rowspan:2)[无],
+    $6 tilde 9$,   table.cell(rowspan:4)[$10^5$], $2000$,
+    $10 tilde 13$,                                table.cell(rowspan:4)[$10^5$],  [A],
+    $14 tilde 17$,                                                                [B],
+    $18 tilde 19$,                                                                table.cell(rowspan:2)[无],
+    $20$,          $10^9$,
+  )
+)
+
+特殊性质 A: 你可以像上面这样创建复杂的表格。

--- a/template/problems/problem-2.typ
+++ b/template/problems/problem-2.typ
@@ -1,0 +1,53 @@
+#import "@preview/fuzzy-cnoi-statement:0.2.0": *
+
+#show: init
+
+#new-problem((
+    name: "桂花树",
+    name-en: "tree",
+    type: "交互型",             // 题目类型
+    time-limit: "0.5 秒",
+    memory-limit: "512 MiB",
+    test-case-count: "10",
+    test-case-equal: "是",
+    year: "2023",
+    // submit-file-name 为提交文件名，可以为 str、content 或一个 extension:str=>content 的函数
+    // submit-file-name: e => {
+    //   show raw: set text(size: 0.8em)
+    //   raw("tree." + e)
+    // } // 将其字体变小
+  ))
+
+*这是一道交互题。*
+
+== 题目描述
+#lorem(50)
+
+== 实现细节
+请确保你的程序开头有 `#include "tree.h"`。
+
+```cpp
+int query(int x, int y);
+void answer(std::vector<int> ans);
+```
+
+```bash
+g++ count.cpp -c -O2 -std=c++14 -lm && g++ count.o grader.o -o count
+```
+
+我能吞下玻璃而不伤身体。
+
+- 赵钱孙李周吴郑王，冯陈楮卫蒋沈韩：
+  - 杨朱秦尤许何吕施张孔。
+    - 曹严华金魏陶姜戚谢。
+  - 邹喻柏水窦章云苏潘葛奚。
+- 范彭郎鲁韦昌马苗凤花，方俞任袁柳酆鲍史唐费廉岑薛雷。
+- 贺倪汤滕殷罗毕郝邬安常乐于时傅皮卞齐康伍余，元卜顾孟平黄和穆萧尹姚邵湛汪，祁毛禹狄米贝明臧计伏成戴。
+
+== 评分标准
+#lorem(50)
+
+#lorem(100)
+
+== 数据范围
+#lorem(50)

--- a/template/problems/problem-3.typ
+++ b/template/problems/problem-3.typ
@@ -1,0 +1,33 @@
+#import "@preview/fuzzy-cnoi-statement:0.2.0": *
+
+#show: init
+
+#new-problem(
+    (
+    name: "深搜",
+    name-en: "dfs",
+    type: "提交答案型",
+    executable: [无],
+    input: [`dfs`$1~10$`.in`],   // 输入文件名
+    output: [`dfs`$1~10$`.out`], // 输出文件名
+    test-case-count: "10",
+    test-case-equal: "是",
+    submit-file-name: [`dfs`$1~10$`.out`],
+  )
+)
+
+== 题目描述
+#lorem(50)
+
+== 输入格式
+从文件 #filename[dfs$1~10$.in] 中读入数据。
+
+#lorem(50)
+
+== 输出格式
+输出到文件 #filename[dfs$1~10$.out] 中。
+
+#lorem(50)
+
+== 数据范围
+对于所有测试数据保证：$1 <= n <= 10^5$。

--- a/typst.toml
+++ b/typst.toml
@@ -1,7 +1,7 @@
 [package]
 name = "fuzzy-cnoi-statement"
-version = "0.1.3"
-entrypoint = "fuzzy-cnoi-statement.typ"
+version = "0.2.0"
+entrypoint = "lib.typ"
 authors = ["Wallbreaker5th"]
 license = "MIT-0"
 description = "A template for CNOI(Olympiad in Informatics in China)-style statements for competitive programming"


### PR DESCRIPTION
提供方法将题目分离到其他的文件中，便于复用题目以及批量的修改试题册中的题目。

第一改 template，若准备合并，建议多看两眼（

顺提：我似乎没看到对 `#import "@preview/codelst:2.0.0": sourcecode` 的使用？或许可以移除。